### PR TITLE
[ENG-000] Patch shutdown method required in the latest urllib3 release

### DIFF
--- a/httpretty/core.py
+++ b/httpretty/core.py
@@ -872,6 +872,9 @@ class fakesock(object):
                 raise UnmockedError('socket cannot recv(): {!r}'.format(self))
 
             return self._read_buf.read(buffersize)
+        
+        def shutdown(self, *args, **kwargs):
+            return self.forward_and_trace('shutdown', *args, **kwargs)
 
         def __getattr__(self, name):
             if name in ('getsockopt', 'selected_alpn_protocol') and not self.truesock:

--- a/httpretty/version.py
+++ b/httpretty/version.py
@@ -1,1 +1,1 @@
-version = '1.1.5a1'
+version = '1.1.6a1'


### PR DESCRIPTION
## Context

urllib3 2.3.0[ added the HTTPResponse.shutdown()](https://github.com/urllib3/urllib3/commit/f7bcf6986fa9c43fc7884b648f66688db593b491#diff-542c95910a277028550d2c8943e8c49bbcb10f9af96e35d0a0eee99b8cfe9e8cR513), which were not been mocked by httprety

https://github.com/urllib3/urllib3/releases/tag/2.3.0

<img width="950" alt="image" src="https://github.com/user-attachments/assets/fa35840b-f0e5-4dac-9adb-61839ed29744" />


## Issues

...

## Solution

...


> 🤖 Generated by Code Guardian
# Changelog
## 🐛 Squashed Bugs
- Patch shutdown required in the latest  urllib3 release (https://github.com/nilohealth/HTTPretty/commit/7cdadcabbbe72c2cdc43256652bc2d53bc057114 by @ninaalves)

